### PR TITLE
fix: increase scan block range in rpc

### DIFF
--- a/frontend/src/UI/pages/explorer/services/transactionService.ts
+++ b/frontend/src/UI/pages/explorer/services/transactionService.ts
@@ -31,9 +31,9 @@ const fetchAllTransactions = async (): Promise<Transaction[]> => {
     const arbCurrentBlock = await arbitrumClient.getBlockNumber()
     const l3CurrentBlock = await bitlazerClient.getBlockNumber()
 
-    // Define block ranges (last ~1M blocks)
-    const arbFromBlock = arbCurrentBlock > 1000000n ? arbCurrentBlock - 1000000n : 0n
-    const l3FromBlock = l3CurrentBlock > 1000000n ? l3CurrentBlock - 1000000n : 0n
+    // Define block ranges (last ~3M blocks to capture more history)
+    const arbFromBlock = arbCurrentBlock > 3000000n ? arbCurrentBlock - 3000000n : 0n
+    const l3FromBlock = l3CurrentBlock > 3000000n ? l3CurrentBlock - 3000000n : 0n
 
     // 1. FETCH WRAP TRANSACTIONS (Arbitrum)
     const wrapLogs = await arbitrumClient.getLogs({


### PR DESCRIPTION
arbm txs are there, they're just far behind. Increasing tx scan block range:
<img width="1600" height="567" alt="image" src="https://github.com/user-attachments/assets/a0ad2d4c-5824-4cfa-9a8d-8ee2b3418df1" />
