### PR TITLE
feat: explorer txs caching & auto-refresh

### DIFF
--- a/frontend/src/UI/pages/explorer/Explorer.tsx
+++ b/frontend/src/UI/pages/explorer/Explorer.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState, useEffect } from 'react'
+import React, { FC, useState, useEffect, useRef } from 'react'
 import { TypewriterText } from '@components/common/TypewriterText'
 import { TransactionList } from './components/TransactionList'
 import { TransactionFilters } from './components/TransactionFilters'
@@ -19,17 +19,50 @@ const Explorer: FC<IExplorer> = () => {
   const [selectedNetwork, setSelectedNetwork] = useState<NetworkType | 'all'>('all')
   const [page, setPage] = useState(1)
   const [hasMore, setHasMore] = useState(true)
+  const [nextRefreshIn, setNextRefreshIn] = useState(30)
   const itemsPerPage = 20
+  const countdownIntervalRef = useRef<NodeJS.Timeout | null>(null)
+  const lastFetchRef = useRef<number>(0)
 
-  // Fetch all transactions only once on mount
+  // Initial load on mount
   useEffect(() => {
-    loadAllTransactions()
+    loadAllTransactions(false)
+  }, [])
+
+  // Set up auto-refresh countdown (30 seconds)
+  useEffect(() => {
+    if (countdownIntervalRef.current) {
+      clearInterval(countdownIntervalRef.current)
+    }
+
+    let countdown = 30 // 30 seconds
+    setNextRefreshIn(countdown)
+
+    countdownIntervalRef.current = setInterval(() => {
+      countdown -= 1
+      if (countdown <= 0) {
+        countdown = 30
+        // Only refresh recent transactions
+        loadAllTransactions(true)
+      }
+      setNextRefreshIn(countdown)
+    }, 1000)
+
+    return () => {
+      if (countdownIntervalRef.current) {
+        clearInterval(countdownIntervalRef.current)
+      }
+    }
   }, [])
 
   // Apply filters when search/filter criteria change
   useEffect(() => {
-    applyFilters()
-  }, [searchQuery, selectedType, selectedNetwork, allTransactions])
+    applyFilters(false)
+  }, [allTransactions])
+
+  useEffect(() => {
+    applyFilters(true) // Reset page on user filter changes
+  }, [searchQuery, selectedType, selectedNetwork])
 
   // Handle pagination
   useEffect(() => {
@@ -39,28 +72,85 @@ const Explorer: FC<IExplorer> = () => {
     setHasMore(end < filteredTransactions.length)
   }, [page, filteredTransactions])
 
-  const loadAllTransactions = async () => {
-    const CACHE_KEY = 'explorer_transactions'
-    const CACHE_TTL = 60 * 1000 // 1 minute cache
+  const loadAllTransactions = async (refreshRecentOnly = false) => {
+    const CACHE_KEY = 'explorer_all_transactions_24h'
+    const CACHE_TTL = 24 * 60 * 60 * 1000 // 24 hours
+    const RECENT_THRESHOLD = 24 * 60 * 60 // 24 hours in seconds
+    const now = Date.now()
 
-    // Try to get cached data first
-    const cachedData = cache.get<Transaction[]>(CACHE_KEY)
-    if (cachedData) {
-      setAllTransactions(cachedData)
-      setLoading(false)
+    // Prevent API spam - minimum 25 seconds between fetches
+    if (refreshRecentOnly && now - lastFetchRef.current < 25000) {
+      console.log('Skipping refresh - too soon since last fetch')
       return
     }
 
-    setLoading(true)
-    try {
-      const data = await fetchTransactions({
-        page: 1,
-        limit: 1000, // Fetch all available transactions
-      })
+    // For initial load, try cache first
+    if (!refreshRecentOnly) {
+      const cachedData = cache.get<Transaction[]>(CACHE_KEY)
+      if (cachedData && cachedData.length > 0) {
+        setAllTransactions(cachedData)
+        setLoading(false)
+        return
+      }
+    }
 
-      // Cache the transactions
-      cache.set(CACHE_KEY, data.transactions, CACHE_TTL)
-      setAllTransactions(data.transactions)
+    // Don't show loading spinner on auto-refresh
+    if (!refreshRecentOnly) {
+      setLoading(true)
+    }
+
+    try {
+      lastFetchRef.current = now
+
+      if (refreshRecentOnly && allTransactions.length > 0) {
+        // Store current displayed count before refresh
+        // const currentDisplayedCount = displayedTransactions.length
+
+        // Auto-refresh: only fetch recent transactions
+        const data = await fetchTransactions({
+          page: 1,
+          limit: 100, // Fetch only recent ones
+          forceRefresh: true,
+        })
+
+        const nowSeconds = now / 1000
+
+        // Get only transactions from last 24h from the new fetch
+        const newRecentTxs = data.transactions.filter((tx) => nowSeconds - tx.timestamp < RECENT_THRESHOLD)
+
+        // Keep old transactions (>24h) from existing list
+        const oldTxs = allTransactions.filter((tx) => nowSeconds - tx.timestamp >= RECENT_THRESHOLD)
+
+        // Create a map of new transactions by hash for quick lookup
+        const newTxMap = new Map(newRecentTxs.map((tx) => [tx.hash, tx]))
+
+        // Update existing recent transactions or add new ones
+        const updatedRecentTxs = allTransactions
+          .filter((tx) => nowSeconds - tx.timestamp < RECENT_THRESHOLD)
+          .map((tx) => newTxMap.get(tx.hash) || tx)
+
+        // Add any completely new transactions
+        const existingHashes = new Set(allTransactions.map((tx) => tx.hash))
+        const brandNewTxs = newRecentTxs.filter((tx) => !existingHashes.has(tx.hash))
+
+        // Combine all and sort
+        const combined = [...brandNewTxs, ...updatedRecentTxs, ...oldTxs]
+        const unique = Array.from(new Map(combined.map((tx) => [tx.hash, tx])).values())
+        const sorted = unique.sort((a, b) => b.timestamp - a.timestamp)
+
+        setAllTransactions(sorted)
+        // Don't update cache on auto-refresh
+      } else {
+        // Initial load: fetch all and cache
+        const data = await fetchTransactions({
+          page: 1,
+          limit: 1000,
+          forceRefresh: false,
+        })
+
+        setAllTransactions(data.transactions)
+        cache.set(CACHE_KEY, data.transactions, CACHE_TTL)
+      }
     } catch (error) {
       console.error('Failed to fetch transactions:', error)
     } finally {
@@ -68,7 +158,7 @@ const Explorer: FC<IExplorer> = () => {
     }
   }
 
-  const applyFilters = () => {
+  const applyFilters = (resetPage = false) => {
     let filtered = [...allTransactions]
 
     // Apply search filter
@@ -93,7 +183,11 @@ const Explorer: FC<IExplorer> = () => {
     }
 
     setFilteredTransactions(filtered)
-    setPage(1) // Reset to first page when filters change
+
+    // Only reset to first page if explicitly requested (user-initiated filter change)
+    if (resetPage) {
+      setPage(1)
+    }
   }
 
   const handleSearch = (query: string) => {
@@ -133,14 +227,14 @@ const Explorer: FC<IExplorer> = () => {
             <p className="text-base md:text-xl text-white font-maison-neue min-h-[1.5rem] md:min-h-[1.75rem]">
               {titleComplete ? (
                 <TypewriterText
-                  text="Track all Bitlazer ecosystem transactions in real-time"
+                  text="Track all Bitlazer ecosystem transactions"
                   delay={30}
                   initialDelay={100}
                   cursor={true}
                   cursorChar="_"
                 />
               ) : (
-                <span className="opacity-0">Track all Bitlazer ecosystem transactions in real-time</span>
+                <span className="opacity-0">Track all Bitlazer ecosystem transactions</span>
               )}
             </p>
           </div>
@@ -166,6 +260,7 @@ const Explorer: FC<IExplorer> = () => {
             onLoadMore={handleLoadMore}
             onSearch={handleSearch}
             searchQuery={searchQuery}
+            nextRefreshIn={nextRefreshIn}
           />
         </div>
       </div>

--- a/frontend/src/UI/pages/explorer/components/TransactionFilters.tsx
+++ b/frontend/src/UI/pages/explorer/components/TransactionFilters.tsx
@@ -80,7 +80,13 @@ export const TransactionFilters: FC<TransactionFiltersProps> = ({
                 <img
                   src={SUPPORTED_CHAINS.bitlazerL3.icon}
                   alt={SUPPORTED_CHAINS.bitlazerL3.name}
-                  className={clsx('w-4 h-4', selectedNetwork === option.value ? 'opacity-100' : 'opacity-70')}
+                  className="w-4 h-4"
+                  style={{
+                    filter:
+                      selectedNetwork === option.value
+                        ? 'invert(1) sepia(1) saturate(0) hue-rotate(0deg) brightness(0) contrast(100%)'
+                        : 'none',
+                  }}
                 />
               )}
               {option.label}

--- a/frontend/src/UI/pages/explorer/components/TransactionItem.tsx
+++ b/frontend/src/UI/pages/explorer/components/TransactionItem.tsx
@@ -6,6 +6,7 @@ import { SUPPORTED_CHAINS } from 'src/web3/chains'
 
 interface TransactionItemProps {
   transaction: Transaction
+  nextRefreshIn?: number
 }
 
 export const TransactionItem: FC<TransactionItemProps> = ({ transaction }) => {

--- a/frontend/src/UI/pages/explorer/components/TransactionList.tsx
+++ b/frontend/src/UI/pages/explorer/components/TransactionList.tsx
@@ -11,6 +11,7 @@ interface TransactionListProps {
   onLoadMore: () => void
   onSearch?: (query: string) => void
   searchQuery?: string
+  nextRefreshIn?: number
 }
 
 export const TransactionList: FC<TransactionListProps> = ({
@@ -20,6 +21,7 @@ export const TransactionList: FC<TransactionListProps> = ({
   onLoadMore,
   onSearch,
   searchQuery = '',
+  nextRefreshIn,
 }) => {
   const [localSearchQuery, setLocalSearchQuery] = React.useState(searchQuery)
   const debounceTimer = useRef<NodeJS.Timeout | null>(null)
@@ -158,13 +160,36 @@ export const TransactionList: FC<TransactionListProps> = ({
               <div className="col-span-1 font-ocrx text-lightgreen-100 text-base uppercase">Block</div>
               <div className="col-span-2 font-ocrx text-lightgreen-100 text-base uppercase">Network</div>
               <div className="col-span-1 font-ocrx text-lightgreen-100 text-base uppercase">Status</div>
-              <div className="col-span-1 font-ocrx text-lightgreen-100 text-base uppercase text-right">Time</div>
+              <div className="col-span-1 font-ocrx text-lightgreen-100 text-base uppercase text-right flex items-center justify-end gap-2">
+                <span>Time</span>
+                {nextRefreshIn !== undefined && (
+                  <div className="flex items-center gap-1">
+                    <svg className="w-3 h-3 -rotate-90 text-white/50" viewBox="0 0 24 24" fill="none">
+                      <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="6" opacity="0.25" />
+                      <circle
+                        cx="12"
+                        cy="12"
+                        r="10"
+                        stroke="currentColor"
+                        strokeWidth="6"
+                        strokeLinecap="round"
+                        fill="none"
+                        style={{
+                          strokeDasharray: `${(nextRefreshIn / 30) * 62.8}px, 62.8px`,
+                          transition: 'stroke-dasharray 1s linear',
+                        }}
+                      />
+                    </svg>
+                    <span className="text-xs font-maison-neue font-bold normal-case">{nextRefreshIn}s</span>
+                  </div>
+                )}
+              </div>
             </div>
 
             {/* Transaction Items */}
             <div className="space-y-3">
               {transactions.map((transaction) => (
-                <TransactionItem key={transaction.id} transaction={transaction} />
+                <TransactionItem key={transaction.id} transaction={transaction} nextRefreshIn={nextRefreshIn} />
               ))}
             </div>
 

--- a/frontend/src/UI/pages/explorer/services/transactionService.ts
+++ b/frontend/src/UI/pages/explorer/services/transactionService.ts
@@ -11,11 +11,12 @@ const bitlazerAPI = new BitlazerAPI()
 
 // Cache configuration
 const CACHE_CONFIG = {
-  TTL: EXPLORER_CONFIG.cacheTimeout,
+  TTL: 24 * 60 * 60 * 1000, // 24 hours for main cache
+  SHORT_TTL: 5 * 60 * 1000, // 5 minutes for refresh cache to prevent spam
   KEYS: {
-    ALL_TRANSACTIONS: 'explorer_all_transactions_v2',
-    ARBISCAN_TRANSACTIONS: 'explorer_arbiscan_transactions',
-    BITLAZER_TRANSACTIONS: 'explorer_bitlazer_transactions',
+    ALL_TRANSACTIONS: 'explorer_all_transactions_v4',
+    ARBISCAN_TRANSACTIONS: 'explorer_arbiscan_transactions_v4',
+    BITLAZER_TRANSACTIONS: 'explorer_bitlazer_transactions_v4',
   },
 }
 
@@ -37,13 +38,15 @@ async function fetchAllTransactions(params: FetchAllTransactionsParams = {}): Pr
     maxTransactionsPerNetwork = 1000,
   } = params
 
+  // For forced refresh, still use short-term cache to prevent API spam
+  const cacheKey = forceRefresh ? `${CACHE_CONFIG.KEYS.ALL_TRANSACTIONS}_refresh` : CACHE_CONFIG.KEYS.ALL_TRANSACTIONS
+  const cacheTTL = forceRefresh ? CACHE_CONFIG.SHORT_TTL : CACHE_CONFIG.TTL
+
   // Check cache first
-  if (!forceRefresh) {
-    const cachedData = cache.get<Transaction[]>(CACHE_CONFIG.KEYS.ALL_TRANSACTIONS)
-    if (cachedData) {
-      console.log('Using cached transactions data')
-      return cachedData
-    }
+  const cachedData = cache.get<Transaction[]>(cacheKey)
+  if (cachedData && cachedData.length > 0) {
+    console.log('Using cached transactions data')
+    return cachedData
   }
 
   console.log('Fetching fresh transactions from explorer APIs...')
@@ -56,11 +59,13 @@ async function fetchAllTransactions(params: FetchAllTransactionsParams = {}): Pr
         includeTokenTransfers,
         includeInternalTransactions,
         maxTransactions: maxTransactionsPerNetwork,
+        forceRefresh,
       }),
       fetchBitlazerTransactions({
         includeTokenTransfers,
         includeInternalTransactions,
         maxTransactions: maxTransactionsPerNetwork,
+        forceRefresh,
       }),
     ])
 
@@ -77,7 +82,15 @@ async function fetchAllTransactions(params: FetchAllTransactionsParams = {}): Pr
     const sortedTransactions = filteredTransactions.sort((a, b) => b.timestamp - a.timestamp)
 
     // Cache the results
-    cache.set(CACHE_CONFIG.KEYS.ALL_TRANSACTIONS, sortedTransactions, CACHE_CONFIG.TTL)
+    cache.set(cacheKey, sortedTransactions, cacheTTL)
+
+    // Also update the main cache if this was a refresh
+    if (forceRefresh && sortedTransactions.length > 0) {
+      const mainCached = cache.get<Transaction[]>(CACHE_CONFIG.KEYS.ALL_TRANSACTIONS)
+      if (!mainCached || mainCached.length === 0) {
+        cache.set(CACHE_CONFIG.KEYS.ALL_TRANSACTIONS, sortedTransactions, CACHE_CONFIG.TTL)
+      }
+    }
 
     return sortedTransactions
   } catch (error) {
@@ -86,11 +99,11 @@ async function fetchAllTransactions(params: FetchAllTransactionsParams = {}): Pr
     // Try to return cached data even if expired
     const expiredCache = cache.get<Transaction[]>(CACHE_CONFIG.KEYS.ALL_TRANSACTIONS)
     if (expiredCache) {
-      console.log('Using cache due to API error')
+      console.log('Using expired cache due to API error')
       return expiredCache
     }
 
-    throw error
+    return []
   }
 }
 
@@ -101,6 +114,7 @@ async function fetchArbitrumTransactions(params: {
   includeTokenTransfers: boolean
   includeInternalTransactions: boolean
   maxTransactions: number
+  forceRefresh?: boolean
 }): Promise<Transaction[]> {
   const transactions: Transaction[] = []
 
@@ -143,8 +157,9 @@ async function fetchArbitrumTransactions(params: {
       }
     })
 
-    // Cache Arbitrum transactions separately
-    cache.set(CACHE_CONFIG.KEYS.ARBISCAN_TRANSACTIONS, transactions, CACHE_CONFIG.TTL)
+    // Cache Arbitrum transactions separately with appropriate TTL
+    const ttl = params.forceRefresh ? CACHE_CONFIG.SHORT_TTL : CACHE_CONFIG.TTL
+    cache.set(CACHE_CONFIG.KEYS.ARBISCAN_TRANSACTIONS, transactions, ttl)
 
     return transactions
   } catch (error) {
@@ -167,6 +182,7 @@ async function fetchBitlazerTransactions(params: {
   includeTokenTransfers: boolean
   includeInternalTransactions: boolean
   maxTransactions: number
+  forceRefresh?: boolean
 }): Promise<Transaction[]> {
   try {
     // Use the new API that fetches via event logs
@@ -175,8 +191,9 @@ async function fetchBitlazerTransactions(params: {
     // Limit the number of transactions if needed
     const limitedTransactions = transactions.slice(0, params.maxTransactions)
 
-    // Cache Bitlazer transactions
-    cache.set(CACHE_CONFIG.KEYS.BITLAZER_TRANSACTIONS, limitedTransactions, CACHE_CONFIG.TTL)
+    // Cache Bitlazer transactions with appropriate TTL
+    const ttl = params.forceRefresh ? CACHE_CONFIG.SHORT_TTL : CACHE_CONFIG.TTL
+    cache.set(CACHE_CONFIG.KEYS.BITLAZER_TRANSACTIONS, limitedTransactions, ttl)
 
     return limitedTransactions
   } catch (error) {

--- a/frontend/src/UI/pages/explorer/services/transactionService.ts
+++ b/frontend/src/UI/pages/explorer/services/transactionService.ts
@@ -11,12 +11,12 @@ const bitlazerAPI = new BitlazerAPI()
 
 // Cache configuration
 const CACHE_CONFIG = {
-  TTL: 24 * 60 * 60 * 1000, // 24 hours for main cache
-  SHORT_TTL: 5 * 60 * 1000, // 5 minutes for refresh cache to prevent spam
+  TTL: 12 * 60 * 60 * 1000, // 12 hours for main cache
+  SHORT_TTL: 30 * 1000, // 30 seconds for refresh cache to prevent spam
   KEYS: {
-    ALL_TRANSACTIONS: 'explorer_all_transactions_v4',
-    ARBISCAN_TRANSACTIONS: 'explorer_arbiscan_transactions_v4',
-    BITLAZER_TRANSACTIONS: 'explorer_bitlazer_transactions_v4',
+    ALL_TRANSACTIONS: 'explorer_all_transactions_v5', // Changed version to clear old cache
+    ARBISCAN_TRANSACTIONS: 'explorer_arbiscan_transactions_v5',
+    BITLAZER_TRANSACTIONS: 'explorer_bitlazer_transactions_v5',
   },
 }
 


### PR DESCRIPTION
- 24-hour caching - All fetched transactions are cached locally for 24 hours
- Auto-refresh - Recent transactions (<24h) auto-refresh every 30 seconds while on the page
- Visual countdown timer - Shows remaining seconds until next refresh with a depleting circle indicator
- Drastically reduced API calls - Optimized to use batch event log fetching instead of individual transaction queries (reduced from 100s of calls to ~5)
- Fixed UI issues - Improved network filter button logo visibility when selected